### PR TITLE
Revision of Binding API of getParameterValueAtIndex and getCompartmentValueAtIndex.

### DIFF
--- a/src/bindings/libsbmlsim.i
+++ b/src/bindings/libsbmlsim.i
@@ -187,7 +187,7 @@ extern void write_separate_result(myResult* result, char* file_s, char* file_p, 
     }
     if (pindex == -1)
       return -0.0;
-    return $self->values_param[index];
+    return $self->values_param[index * $self->num_of_columns_param + pindex];
   }
 
   double getCompartmentValueAtIndex(char *cname, int index) {
@@ -203,7 +203,7 @@ extern void write_separate_result(myResult* result, char* file_s, char* file_p, 
     }
     if (cindex == -1)
       return -0.0;
-    return $self->values_comp[index];
+    return $self->values_comp[index * $self->num_of_columns_comp + cindex];
   }
 
 };


### PR DESCRIPTION
Dear Developers of libSBMLSim team.

Hi, I'm Takahiro Yamada. Thank you for your great software, libSBMLSim.
I noticed that binding API of getParameterValueAtIndex and getCompartmentValueAtIndex ignore the first argument (parameter name and compartment name), so that the values in designated time (argument 2) cannot be extracted if these parameters and compartments are dynamically changing.
I attached the sample code to check the results from sample model (https://www.ebi.ac.uk/biomodels/MODEL1006230050) as follows (Sample code is just for Java),

```
import jp.ac.keio.bio.fun.libsbmlsim.libsbmlsim;
import jp.ac.keio.bio.fun.libsbmlsim.myResult;

public class TestLibSBMLSim {
	static{
		System.loadLibrary("sbmlsimj");
	}
	public static void main(String[] args){
		// MODEL1006230050_url.xml : From https://www.ebi.ac.uk/biomodels/MODEL1006230050
		// All variables are described as Parameters

		myResult r = libsbmlsim.simulateSBMLFromFile("./MODEL1006230050_url.xml", 100, 1, 1, 0, libsbmlsim.MTHD_RUNGE_KUTTA_FEHLBERG_5, 0);

		libsbmlsim.write_csv( r , "./result.csv");
		// Commit Hash : Head of master (commit hash : cb666fc8)
                // Contents of result.csv is as follows.
		/*time,lambda,d,x,beta,a,y,k,u,v,COMpartment
		0,1,0.01,100,0.05,0.5,0,1,1,5,1
		1,1,0.01,74.90693472496817,0.05,0.5,20.23868622405949,1,1,9.138257417625164,1
		2,1,0.01,32.82271243601735,0.05,0.5,46.09430759542048,1,1,25.87819868068561,1
		3,1,0.01,6.145501628101504,0.05,0.5,48.57813587258317,1,1,41.26874234945059,1
		4,1,0.01,1.152492110723685,0.05,0.5,33.82755975877057,1,1,40.58571355831041,1
		5,1,0.01,0.6603779566906354,0.05,0.5,21.63080053948467,1,1,31.57848351477819,1
		...
		*/
		
		int numTime = r.getNum_of_rows();
		System.out.println( r.getParameterNameAtIndex( 0 ));
		// -> lambda, that means this model obtains the dynamically changing parameter.
		
		// print the time variation of these parameters
		System.out.print("time,");
		
		for( int i = 0 ; i < r.getNum_of_columns_param() ; i ++ ){
			if( i == r.getNum_of_columns_param() - 1 ){
				System.out.println( r.getParameterNameAtIndex( i ));
			}
			else{
				System.out.print( r.getParameterNameAtIndex( i ) + ",");
			}
			
		}
		for( int i = 0 ; i < r.getNum_of_rows() ; i ++ ){
			System.out.print( r.getTimeValueAtIndex( i ) + ",");
			for( int j = 0 ; j < r.getNum_of_columns_param() ; j ++){
				System.out.print( r.getParameterValueAtIndex( r.getParameterNameAtIndex( j ), i) + ",");
			}
			System.out.println();
		}
		
		/*
		// Head of master (commit hash : cb666fc8)
		// the first argument of r.getParameterValueAtIndex is ignored!
		time,lambda,d,x,beta,a,y,k,u,v
		0.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,
		1.0,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,0.01,
		2.0,100.0,100.0,100.0,100.0,100.0,100.0,100.0,100.0,100.0,
		3.0,0.05,0.05,0.05,0.05,0.05,0.05,0.05,0.05,0.05,
		4.0,0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5,
		5.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,
		...
		 */
		
		/*
		 * 
		// Patch version (commit hash : cb666fc8)
                // This result matches the libsbmlsim.write_csv (result.csv) only for parameters
		time,lambda,d,x,beta,a,y,k,u,v
		0.0,1.0,0.01,100.0,0.05,0.5,0.0,1.0,1.0,5.0,
		1.0,1.0,0.01,74.90693472496817,0.05,0.5,20.238686224059492,1.0,1.0,9.138257417625164,
		2.0,1.0,0.01,32.82271243601735,0.05,0.5,46.09430759542048,1.0,1.0,25.878198680685614,
		3.0,1.0,0.01,6.1455016281015045,0.05,0.5,48.57813587258317,1.0,1.0,41.26874234945059,
		4.0,1.0,0.01,1.1524921107236847,0.05,0.5,33.82755975877057,1.0,1.0,40.58571355831041,
		5.0,1.0,0.01,0.6603779566906354,0.05,0.5,21.630800539484667,1.0,1.0,31.57848351477819,
		 */
	}
}
```

So, I slightly revise the ``/src/bindings/libsbmlsim.i`` to get the values using the information of first argument by these API.
I hope this fix might lead to improvements in libSBMLSim.

Best.

Takahiro